### PR TITLE
Highlight inline code

### DIFF
--- a/exampleVault/index.md
+++ b/exampleVault/index.md
@@ -99,3 +99,7 @@ echo "Hello"
 > - this line will be marked as deleted
 >   this is a regular line
 > ```
+
+Inline code
+
+`{jsx} <button role="button" />`

--- a/src/codemirror/Cm6_Util.ts
+++ b/src/codemirror/Cm6_Util.ts
@@ -1,4 +1,4 @@
-import { type EditorState } from '@codemirror/state';
+import { type EditorState, type EditorSelection } from '@codemirror/state';
 import { type DecorationSet } from '@codemirror/view';
 
 export class Cm6_Util {
@@ -12,6 +12,22 @@ export class Cm6_Util {
 	 */
 	static checkRangeOverlap(fromA: number, toA: number, fromB: number, toB: number): boolean {
 		return fromA <= toB && fromB <= toA;
+	}
+
+	/**
+	 * Checks if editor selection and the given range overlap.
+	 *
+	 * @param selection
+	 * @param from
+	 * @param to
+	 */
+	static checkSelectionAndRangeOverlap(selection: EditorSelection, from: number, to: number): boolean {
+        for (const r of selection.ranges) {
+            if (r.from < to && r.to > from) {
+                return true;
+            }
+        }
+        return false;
 	}
 
 	/**

--- a/styles.css
+++ b/styles.css
@@ -81,3 +81,15 @@ div.expressive-code {
 div.markdown-preview-view > div > div.mod-header + div > div.block-language-yaml.shiki-hide-in-reading-mode {
 	display: none;
 }
+
+.shiki-inline {
+	& .bold {
+		font-weight: var(--bold-weight, 600);
+	}
+	& .italic {
+		font-style: italic;
+	}
+	& .ul {
+		text-decoration: underline;
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -83,13 +83,13 @@ div.markdown-preview-view > div > div.mod-header + div > div.block-language-yaml
 }
 
 .shiki-inline {
-	& .bold {
+	& .shiki-bold {
 		font-weight: var(--bold-weight, 600);
 	}
-	& .italic {
+	& .shiki-italic {
 		font-style: italic;
 	}
-	& .ul {
+	& .shiki-ul {
 		text-decoration: underline;
 	}
 }


### PR DESCRIPTION
Highlight inline code of format: `{lang} code`, Close #10.

Example: `{jsx} <button role="button" />`

https://github.com/mProjectsCode/obsidian-shiki-plugin/assets/69613663/43db3003-cc6c-4ad6-85e5-6d340c67b765

