### PR TITLE
Reduce startup time

### DIFF
--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -38,7 +38,7 @@ export class CodeHighlighter {
 
 	ec!: ExpressiveCodeEngine;
 	ecElements!: HTMLElement[];
-	loadedLanguages!: string[];
+	supportedLanguages!: string[];
 	shiki!: Highlighter;
 	customThemes!: CustomTheme[];
 	customLanguages!: LanguageRegistration[];
@@ -55,7 +55,10 @@ export class CodeHighlighter {
 		await this.loadEC();
 		await this.loadShiki();
 
-		this.loadedLanguages = this.shiki.getLoadedLanguages();
+		this.supportedLanguages = [
+			...Object.keys(bundledLanguages),
+			...this.customLanguages.map(i => i.name)
+		];
 	}
 
 	async unload(): Promise<void> {
@@ -143,7 +146,7 @@ export class CodeHighlighter {
 			themes: [new ExpressiveCodeTheme(await this.themeMapper.getThemeForEC())],
 			plugins: [
 				pluginShiki({
-					langs: this.getLoadedLanguageRegistrations(),
+					langs: [...this.customLanguages],
 				}),
 				pluginCollapsibleSections(),
 				pluginTextMarkers(),
@@ -179,7 +182,7 @@ export class CodeHighlighter {
 	async loadShiki(): Promise<void> {
 		this.shiki = await createHighlighter({
 			themes: [await this.themeMapper.getTheme()],
-			langs: this.getLoadedLanguageRegistrations(),
+			langs: [...this.customLanguages],
 		});
 	}
 
@@ -198,7 +201,7 @@ export class CodeHighlighter {
 	 * All languages that are safe to use with Obsidian's `registerMarkdownCodeBlockProcessor`.
 	 */
 	obsidianSafeLanguageNames(): string[] {
-		return this.loadedLanguages.filter(lang => !languageNameBlacklist.has(lang) && !this.plugin.loadedSettings.disabledLanguages.includes(lang));
+		return this.supportedLanguages.filter(lang => !languageNameBlacklist.has(lang) && !this.plugin.loadedSettings.disabledLanguages.includes(lang));
 		// .concat(this.customLanguages.map(lang => lang.name));
 	}
 
@@ -215,11 +218,16 @@ export class CodeHighlighter {
 		container.innerHTML = toHtml(this.themeMapper.fixAST(result.renderedGroupAst));
 	}
 
-	getHighlightTokens(code: string, lang: string): TokensResult | undefined {
+	async getHighlightTokens(code: string, lang: string): Promise<TokensResult | undefined> {
 		if (!this.obsidianSafeLanguageNames().includes(lang)) {
 			return undefined;
 		}
-
+		// load bundled language ​​when needed
+		try {
+			this.shiki.getLanguage(lang);
+		} catch (e) {
+			await this.shiki.loadLanguage(lang as BundledLanguage);
+		}
 		return this.shiki.codeToTokens(code, {
 			lang: lang as BundledLanguage,
 			theme: this.plugin.settings.theme,

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,12 +115,12 @@ export default class ShikiPlugin extends Plugin {
 	}
 
 	registerInlineCodeProcessor(): void {
-		this.registerMarkdownPostProcessor((el, ctx) => {
+		this.registerMarkdownPostProcessor(async (el, ctx) => {
 			const inlineCodes = el.findAll(':not(pre) > code');
 			for (let codeElm of inlineCodes) {
 				let match = codeElm.textContent?.match(SHIKI_INLINE_REGEX); // format: `{lang} code`
 				if (match) {
-					const highlight = this.highlighter.getHighlightTokens(match[2], match[1]);
+					const highlight = await this.highlighter.getHighlightTokens(match[2], match[1]);
 					const tokens = highlight?.tokens.flat(1);
 					if (!tokens?.length) {
 						continue;

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -135,7 +135,7 @@ export class ShikiSettingsTab extends PluginSettingTab {
 			.setDesc('Configure language to exclude.')
 			.addButton(button => {
 				button.setButtonText('Add Language Rule').onClick(() => {
-					const modal = new StringSelectModal(this.plugin, this.plugin.highlighter.loadedLanguages, language => {
+					const modal = new StringSelectModal(this.plugin, this.plugin.highlighter.supportedLanguages, language => {
 						this.plugin.settings.disabledLanguages.push(language);
 						void this.plugin.saveSettings();
 						this.display();


### PR DESCRIPTION
Fix #39. The change in startup time is shown in the figure below (recorded by `exampleVault`):

<div style:"display:flex;">
  <img src="https://github.com/user-attachments/assets/d2fd2b3c-72eb-4029-a4a5-538e77219e93" height="300"/>
  <img src="https://github.com/user-attachments/assets/54122cdd-9837-423c-92ff-de2506f0c21a" height="300"/>
</div>

- _left_: load all languages at once → slow startup
- _right_: load on demand → starts faster, functions as usual

References:
- https://shiki.style/guide/install#usage
- https://expressive-code.com/key-features/syntax-highlighting/#langs

Note:
- For on-demand loading, `async / await` is added to the code that requires highlighter instance `this.shiki` to load language. Not sure if it will have any impact.
- In the `updateWidgets` function, the steps of building decorations are moved outside `syntaxTree.iterate`. 