### PR TITLE
Support render shiki special language like 'ansi' and 'plaintext'

### DIFF
--- a/src/Highlighter.ts
+++ b/src/Highlighter.ts
@@ -31,6 +31,9 @@ interface CustomTheme {
 // some languages break obsidian's `registerMarkdownCodeBlockProcessor`, so we blacklist them
 const LANGUAGE_BLACKLIST = new Set(['c++', 'c#', 'f#', 'mermaid']);
 
+// some languages are considered "special" by shiki.isSpecialLang
+const LANGUAGE_SPECIAL = new Set(['plaintext', 'txt', 'text', 'plain', 'ansi']);
+
 export class CodeHighlighter {
 	plugin: ShikiPlugin;
 	themeMapper: ThemeMapper;
@@ -54,7 +57,7 @@ export class CodeHighlighter {
 		await this.loadEC();
 		await this.loadShiki();
 
-		this.supportedLanguages = [...Object.keys(bundledLanguages), ...this.customLanguages.map(i => i.name)];
+		this.supportedLanguages = [...Object.keys(bundledLanguages), ...LANGUAGE_SPECIAL, ...this.customLanguages.map(i => i.name)];
 	}
 
 	async unload(): Promise<void> {


### PR DESCRIPTION
Shiki [supports](https://shiki.style/languages#ansi) displaying the `ansi` special language, and recently, Windows Terminal also [supports](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/actions#copy) copying text with ANSI Control Sequences.

By combining the two, one can display colored code blocks in Markdown. The obsidian-shiki-plugin does not handle special languages like ansi/plaintext, and this PR adds support for them.


Preview: 
<img width="1247" height="1098" alt="PixPin_2025-09-03_02-56-56" src="https://github.com/user-attachments/assets/d4470a48-b346-424d-9215-b8391e3aea3a" />
